### PR TITLE
Return undefined only when arr[index] is undefined 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phanect/utils",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "@phanect's personal utility library for JavaScript & TypeScript",
   "repository": {
     "type": "git",

--- a/src/universal/get-last-element-of.ts
+++ b/src/universal/get-last-element-of.ts
@@ -29,14 +29,10 @@ export function getLastElementOf<T>(
   if (withIndex === true) {
     const index = arr.length - 1;
 
-    if (arr[index]) {
-      return {
-        el: arr[index],
-        index,
-      };
-    } else {
-      return undefined;
-    }
+    return {
+      el: arr[index],
+      index,
+    };
   } else {
     return arr[arr.length - 1];
   }

--- a/src/universal/get-last-element-of.ts
+++ b/src/universal/get-last-element-of.ts
@@ -19,7 +19,7 @@ export function getLastElementOf<T>(
   options: {
     withIndex?: boolean;
   } = {},
-): T | { el: T; index: number; } | undefined {
+): T | { el: T | undefined; index: number; } | undefined {
   if (arr.length <= 0) {
     return undefined;
   }

--- a/test/universal/get-last-element-of.test.ts
+++ b/test/universal/get-last-element-of.test.ts
@@ -30,3 +30,30 @@ test("getLastElementOf (with index, empty array given)", () => {
 
   expect(lastElement).toBeUndefined();
 });
+
+test("undefined element (without index)", () => {
+  const lastElement = getLastElementOf([ "a", "b", undefined, "c", undefined ], { withIndex: false });
+
+  expect(lastElement).toBeUndefined();
+});
+
+test("undefined element (with index)", () => {
+  const { el, index } = getLastElementOf([ "a", "b", undefined, "c", undefined ], { withIndex: true }) ?? {};
+
+  expect(el).toBeUndefined();
+  expect(index).toBe(4);
+});
+
+test("false element (with index)", () => {
+  const { el, index } = getLastElementOf([ "a", "b", false ], { withIndex: true }) ?? {};
+
+  expect(el).toBe(false);
+  expect(index).toBe(2);
+});
+
+test("empty string element (with index)", () => {
+  const { el, index } = getLastElementOf([ "a", "b", "" ], { withIndex: true }) ?? {};
+
+  expect(el).toBe("");
+  expect(index).toBe(2);
+});


### PR DESCRIPTION
Fix a bug caused by #55.